### PR TITLE
use record where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository houses the API source code of of the appointment planner exercise.
 
-The JavaDoc can be found at [https://fontysvenlo.github.io/alda_appointmentplanner_api/v1.2.1](https://fontysvenlo.github.io/alda_appointmentplanner_api/v1.2.1).
+The JavaDoc can be found at [https://fontysvenlo.github.io/alda_appointmentplanner_api/v1.2.2](https://fontysvenlo.github.io/alda_appointmentplanner_api/v1.2.2).
 
 ## Instructions
 

--- a/src/main/java/appointmentplanner/api/Appointment.java
+++ b/src/main/java/appointmentplanner/api/Appointment.java
@@ -3,6 +3,8 @@
  */
 package appointmentplanner.api;
 
+import java.time.Duration;
+
 /**
  * Appointment that is scheduled using the appointment planner.
  *
@@ -26,21 +28,21 @@ public interface Appointment extends TimeSlot, AppointmentData {
      * @return Priority.
      */
     @Override
-    Priority getPriority();
+    Priority priority();
 
     /**
      * Get the appointment data for this appointment.
      *
      * @return the data
      */
-    AppointmentData getAppointmentData();
+    AppointmentData appointmentData();
 
     /**
      * Get the request that led to this appointment.
      *
      * @return the request.
      */
-    AppointmentRequest getRequest();
+    AppointmentRequest request();
 
     /**
      * Override the default toString. toString() returns startTime, endTime,
@@ -68,4 +70,14 @@ public interface Appointment extends TimeSlot, AppointmentData {
      */
     @Override
     public int hashCode();
+
+    /**
+     * Resolves diamond problem. Git the TimeSlot implementation preference.
+     *
+     * @return the duration of the time slot.
+     */
+    @Override
+    default Duration duration() {
+        return TimeSlot.super.duration();
+    }
 }

--- a/src/main/java/appointmentplanner/api/AppointmentData.java
+++ b/src/main/java/appointmentplanner/api/AppointmentData.java
@@ -21,21 +21,21 @@ public interface AppointmentData {
      *
      * @return the duration of the appointment.
      */
-    Duration getDuration();
+    Duration duration();
 
     /**
      * The description of the appointment.
      *
      * @return non-empty string describing the appointment.
      */
-    String getDescription();
+    String description();
 
     /**
      * Get the priority for the appointment.
      *
      * @return the priority
      */
-    Priority getPriority();
+    Priority priority();
 
     /**
      * Get the textual representation of AppointmentData. Contains description,

--- a/src/main/java/appointmentplanner/api/AppointmentRequest.java
+++ b/src/main/java/appointmentplanner/api/AppointmentRequest.java
@@ -30,7 +30,8 @@ import java.time.LocalTime;
  */
 public interface AppointmentRequest extends AppointmentData {
 
-    //TODO Specify how to deal with TimePreferences EARLIEST_AFTER and LATEST_BEFORE together with startTime null
+    // TODO Specify how to deal with TimePreferences EARLIEST_AFTER and LATEST_BEFORE
+    // in combination with startTime null
 
 
     /**
@@ -63,7 +64,7 @@ public interface AppointmentRequest extends AppointmentData {
      *
      * @return the time preference
      */
-    default TimePreference getTimePreference() {
+    default TimePreference timePreference() {
         return TimePreference.UNSPECIFIED;
     }
 

--- a/src/main/java/appointmentplanner/api/AppointmentRequest.java
+++ b/src/main/java/appointmentplanner/api/AppointmentRequest.java
@@ -9,29 +9,29 @@ import java.time.LocalTime;
  *
  * Note that an appointment request is NOT an appointment but only an expression
  * of intent!
- * 
+ *
  * The AppointmentRequest is not input for the external API, but it is returned
  * when removing Appointment(s). The idea is that, based on the AppointmentRequest
  * of the removed Appointment, the appointment could be rescheduled.
- * 
- * The AppointmentRequest is mainly used internally in the TimeLine, when an 
+ *
+ * The AppointmentRequest is mainly used internally in the TimeLine, when an
  * actual appointment is created.
- * 
- * The AppointmentRequest holds LocalTime startTime, AppointmentData and 
+ *
+ * The AppointmentRequest holds LocalTime startTime, AppointmentData and
  * TimePreference. Normally, either startTime or TimePreference is not null. If
- * no TimePreference is set, it defaults to TimePreference.UNSPECIFIED. An 
- * AppointmentRequest with no startTime defined and with TimePreference 
+ * no TimePreference is set, it defaults to TimePreference.UNSPECIFIED. An
+ * AppointmentRequest with no startTime defined and with TimePreference
  * UNSPECIFIED means that the invoker does not have any preference regarding
  * time. It's up to the addAppointment method to decide how to deal with such a
  * request.
- * 
+ *
  * @author Pieter van den Hombergh
  * @author Richard van den Ham
  */
 public interface AppointmentRequest extends AppointmentData {
-    
+
     //TODO Specify how to deal with TimePreferences EARLIEST_AFTER and LATEST_BEFORE together with startTime null
-    
+
 
     /**
      * Get the start time of the intended appointment.
@@ -39,8 +39,8 @@ public interface AppointmentRequest extends AppointmentData {
      * @param onDay the LocalDay the time is on.
      * @return the start time as instant, potentially null.
      */
-    default Instant getStart( LocalDay onDay ) {
-        return onDay.ofLocalTime( getStartTime() );
+    default Instant start(LocalDay onDay) {
+        return onDay.ofLocalTime( startTime() );
     }
 
     /**
@@ -48,14 +48,14 @@ public interface AppointmentRequest extends AppointmentData {
      *
      * @return the start time
      */
-    LocalTime getStartTime();
+    LocalTime startTime();
 
     /**
      * Get the appointment details of this appointment.
      *
      * @return the data
      */
-    AppointmentData getAppointmentData();
+    AppointmentData appointmentData();
 
     /**
      * Time preference given with this appointment request.
@@ -72,10 +72,11 @@ public interface AppointmentRequest extends AppointmentData {
      * @return the duration of the request
      */
     @Override
-    default Duration getDuration() {
-        return getAppointmentData().getDuration();
+    default Duration duration() {
+        return appointmentData()
+                .duration();
     }
-    
+
     /**
      * Defines equality, must be based on all fields of this class.
      * @param obj the other object to check equality with
@@ -83,13 +84,13 @@ public interface AppointmentRequest extends AppointmentData {
      */
     @Override
     public boolean equals( Object obj );
-    
+
     /**
      * Calculate a hash code value for the object.
      * @return hashCode for this object.
      */
     @Override
     public int hashCode();
-    
-    
+
+
 }

--- a/src/main/java/appointmentplanner/api/LocalDay.java
+++ b/src/main/java/appointmentplanner/api/LocalDay.java
@@ -11,10 +11,7 @@ import java.util.Objects;
  *
  * @author Pieter van den Hombergh {@code p.vandenhombergh@fontys.nl}
  */
-public class LocalDay {
-
-    private final ZoneId zone;
-    private final LocalDate date;
+public record LocalDay(ZoneId zone, LocalDate date) {
 
     /**
      * Create a local day in the given timezone at the given date.
@@ -22,9 +19,9 @@ public class LocalDay {
      * @param zone the timezone to use
      * @param date the LocalDate to use
      */
-    public LocalDay( ZoneId zone, LocalDate date ) {
-        this.zone = zone;
-        this.date = date;
+    public LocalDay  {
+        Objects.requireNonNull( zone, "zone must not be null" );
+        Objects.requireNonNull( date, "date must not be null" );
     }
 
     /**
@@ -32,23 +29,6 @@ public class LocalDay {
      */
     public LocalDay() {
         this( ZoneId.systemDefault(), LocalDate.now() );
-    }
-
-    /**
-     * Get the date.
-     * @return the date
-     */
-    public LocalDate getDate() {
-        return date;
-    }
-
-    /**
-     * Get the timezone identifier.
-     *
-     * @return timezone identifier
-     */
-    public ZoneId getZone() {
-        return zone;
     }
 
     /**
@@ -111,34 +91,4 @@ public class LocalDay {
         return new LocalDay();
     }
 
-    @Override
-    public String toString() {
-        return "LocalDay{" + "zone=" + zone + ", date=" + date + '}';
-    }
-
-    @Override
-    public int hashCode() {
-        int hash = 7;
-        hash = 73 * hash + Objects.hashCode( this.zone );
-        hash = 73 * hash + Objects.hashCode( this.date );
-        return hash;
-    }
-
-    @Override
-    public boolean equals( Object obj ) {
-        if ( this == obj ) {
-            return true;
-        }
-        if ( obj == null ) {
-            return false;
-        }
-        if ( getClass() != obj.getClass() ) {
-            return false;
-        }
-        final LocalDay other = (LocalDay) obj;
-        if ( !Objects.equals( this.zone, other.zone ) ) {
-            return false;
-        }
-        return Objects.equals( this.date, other.date );
-    }
 }

--- a/src/main/java/appointmentplanner/api/LocalDayPlan.java
+++ b/src/main/java/appointmentplanner/api/LocalDayPlan.java
@@ -29,7 +29,7 @@ public interface LocalDayPlan {
      *
      * @return the day
      */
-    LocalDay getDay();
+    LocalDay localDay();
 
     /**
      * Start time of the day, inclusive.
@@ -51,15 +51,15 @@ public interface LocalDayPlan {
      *
      * @return the timeline used by this LocalDayPlan
      */
-    Timeline getTimeline();
+    Timeline timeline();
 
     /**
      * Get the allowed first time for this day.
      *
      * @return the start time of this plan
      */
-    default LocalTime getStartTime() {
-        return getDay().timeOfInstant(startOfDay() );
+    default LocalTime startTime() {
+        return localDay().timeOfInstant( startOfDay() );
     }
 
     /**
@@ -67,8 +67,8 @@ public interface LocalDayPlan {
      *
      * @return the end time in this plan
      */
-    default LocalTime getEndTime() {
-        return getDay().timeOfInstant(endOfDay() );
+    default LocalTime endTime() {
+        return localDay().timeOfInstant( endOfDay() );
     }
 
     /**
@@ -83,7 +83,8 @@ public interface LocalDayPlan {
     default Optional<Appointment> addAppointment( AppointmentData appointmentData,
                                                   LocalTime start,
                                                   TimePreference fallback ) {
-        return getTimeline().addAppointment( getDay(), appointmentData, start, fallback );
+        return timeline().addAppointment( localDay(), appointmentData, start,
+                fallback );
     }
 
     /**
@@ -95,7 +96,8 @@ public interface LocalDayPlan {
      * @return Optional Appointment
      */
     default Optional<Appointment> addAppointment( AppointmentData appointmentData, LocalTime startTime ) {
-        return getTimeline().addAppointment( getDay(), appointmentData, startTime );
+        return timeline()
+                .addAppointment( localDay(), appointmentData, startTime );
     }
 
     /**
@@ -108,7 +110,8 @@ public interface LocalDayPlan {
      * @return Optional Appointment
      */
     default Optional<Appointment> addAppointment( AppointmentData appointmentData, TimePreference preference ) {
-        return getTimeline().addAppointment( getDay(), appointmentData, preference );
+        return timeline().addAppointment( localDay(), appointmentData,
+                preference );
     }
 
     /**
@@ -118,7 +121,7 @@ public interface LocalDayPlan {
      * @return AppointmentRequest, the original appointment request
      */
     default AppointmentRequest removeAppointment( Appointment appointment ) {
-        return getTimeline().removeAppointment( appointment );
+        return timeline().removeAppointment( appointment );
     }
 
     /**
@@ -128,68 +131,70 @@ public interface LocalDayPlan {
      * @return all appointment requests of removed appointments
      */
     default List<AppointmentRequest> removeAppointments( Predicate<Appointment> filter ) {
-        return getTimeline().removeAppointments( filter );
+        return timeline().removeAppointments( filter );
     }
 
     /**
-     * {@link Timeline#getAppointments()}.
+     * {@link Timeline#appointments()}.
      *
      * @return all appointments
      */
-    default List<Appointment> getAppointments() {
-        return getTimeline().getAppointments();
+    default List<Appointment> appointments() {
+        return timeline().appointments();
     }
 
     /**
-     * See {@link Timeline#getMatchingFreeSlotsOfDuration(Duration, List)}.
+     * See {@link Timeline#matchingFreeSlotsOfDuration(Duration, List)}.
      *
      * @param duration Minimum duration of the slots
      * @param plans that could have common gaps
      * @return the list of gaps this and each of the other plans have in common
      * with a minimum length of duration.
      */
-    default List<TimeSlot> getMatchingFreeSlotsOfDuration( Duration duration, List<LocalDayPlan> plans ) {
-        return getTimeline().getMatchingFreeSlotsOfDuration( duration, plans.stream().map( LocalDayPlan::getTimeline ).collect( toList() ) );
+    default List<TimeSlot> matchingFreeSlotsOfDuration(Duration duration,
+            List<LocalDayPlan> plans) {
+        return timeline().matchingFreeSlotsOfDuration( duration, plans
+                .stream().map( LocalDayPlan::timeline ).collect( toList() ) );
     }
 
     /**
-     * See {@link Timeline#getGapsFitting(Duration)}.
+     * See {@link Timeline#gapsFitting(Duration)}.
      *
      * @param duration the minimum duration that should fit
-     * @return list of timeslots that fit the duration
+     * @return list of time slots that fit the duration
      */
-    default List<TimeSlot> getGapsFitting( Duration duration ) {
-        return getTimeline().getGapsFitting( duration );
+    default List<TimeSlot> gapsFitting(Duration duration) {
+        return timeline().gapsFitting( duration );
     }
 
     /**
-     * {@link Timeline#getGapsFittingReversed(Duration)}.
+     * {@link Timeline#gapsFittingReversed(Duration)}.
      *
      * @param duration the minimum duration that should fit
-     * @return list of timeslots that fit the duration
+     * @return list of time slots that fit the duration
      */
-    default List<TimeSlot> getGapsFittingReversed( Duration duration ) {
-        return getTimeline().getGapsFittingReversed( duration );
+    default List<TimeSlot> gapsFittingReversed(Duration duration) {
+        return timeline().gapsFittingReversed( duration );
     }
 
     /**
-     * See{@link Timeline#getGapsFittingLargestFirst(Duration)}.
+     * See{@link Timeline#gapsFittingLargestFirst(Duration)}.
      *
      * @param duration the minimum duration
      * @return list of gaps fitting the duration
      */
-    default List<TimeSlot> getGapsFittingLargestFirst( Duration duration ) {
-        return getTimeline().getGapsFittingLargestFirst( duration );
+    default List<TimeSlot> gapsFittingLargestFirst(Duration duration) {
+        return timeline().gapsFittingLargestFirst( duration );
     }
 
     /**
-     * {@link Timeline#getGapsFittingSmallestFirst(Duration)}.
+     * {@link Timeline#gapsFittingSmallestFirst(Duration)}.
      *
      * @param duration the minimum duration
-     * @return list of timeslots fitting the duration
+     * @return list of time slots fitting the duration
      */
-    default List<TimeSlot> getGapsFittingSmallestFirst( Duration duration ) {
-        return getTimeline().getGapsFittingSmallestFirst( duration );
+    default List<TimeSlot> gapsFittingSmallestFirst(Duration duration) {
+        return timeline().gapsFittingSmallestFirst( duration );
     }
 
     /**
@@ -199,7 +204,7 @@ public interface LocalDayPlan {
      * @return true of a gap is available, false otherwise
      */
     default boolean canAddAppointmentOfDuration( Duration duration ) {
-        return getTimeline().canAddAppointmentOfDuration( duration );
+        return timeline().canAddAppointmentOfDuration( duration );
     }
 
     /**
@@ -209,7 +214,7 @@ public interface LocalDayPlan {
      * @return list of appointments that fit the filter
      */
     default List<Appointment> findAppointments( Predicate<Appointment> filter ) {
-        return getTimeline().findAppointments( filter );
+        return timeline().findAppointments( filter );
     }
 
     /**
@@ -228,7 +233,7 @@ public interface LocalDayPlan {
      * @return true if present, false otherwise
      */
     default boolean contains( Appointment appointment ) {
-        return getTimeline().contains( appointment );
+        return timeline().contains( appointment );
     }
 
     /**
@@ -236,17 +241,17 @@ public interface LocalDayPlan {
      *
      * @return the date according to this LocalDayPlan's time zone
      */
-    default LocalDate getDate() {
-        return getDay().getDate();
+    default LocalDate date() {
+        return localDay().date();
     }
 
     /**
-     * {@link Timeline#getNrOfAppointments()}.
+     * {@link Timeline#nrOfAppointments()}.
      *
      * @return number of appointments
      */
-    default int getNrOfAppointments() {
-        return getTimeline().getNrOfAppointments();
+    default int nrOfAppointments() {
+        return timeline().nrOfAppointments();
     }
 
     /**
@@ -257,7 +262,7 @@ public interface LocalDayPlan {
      * @return the point in time as Instant
      */
     default Instant at( int hour, int minute ) {
-        return getDay().at( hour, minute );
+        return localDay().at( hour, minute );
     }
 
 }

--- a/src/main/java/appointmentplanner/api/TimeSlot.java
+++ b/src/main/java/appointmentplanner/api/TimeSlot.java
@@ -14,7 +14,7 @@ import java.time.LocalTime;
  *
  * The implementer should implement a proper to string showing start instant,
  * end instant and duration of this slot.
- * 
+ *
  * The time slots are comparable by length of the slot only!
  * If you keep the slots in a linked list there is no need to compare them
  * by start or end time, because the list will keep them in natural order.
@@ -33,7 +33,7 @@ public interface TimeSlot extends Comparable<TimeSlot> {
      *
      * @return the start time
      */
-    Instant getStart();
+    Instant start();
 
     /**
      * Get the end of the TimeSlot. The end time is NOT included in the
@@ -41,7 +41,7 @@ public interface TimeSlot extends Comparable<TimeSlot> {
      *
      * @return the end time
      */
-    Instant getEnd();
+    Instant end();
 
     /**
      * Get the duration of this slot.
@@ -51,7 +51,7 @@ public interface TimeSlot extends Comparable<TimeSlot> {
      * @return the duration as Duration
      */
     default Duration duration() {
-        return Duration.between( getStart(), getEnd() );
+        return Duration.between( start(), end() );
     }
 
     /**
@@ -79,13 +79,15 @@ public interface TimeSlot extends Comparable<TimeSlot> {
     /**
      * Does the given time slot fit inside this time slot.
      *
-     * @param other Timeslot to test
+     * @param other TimeSlot to test
      * @return true if other does not start earlier nor ends earlier than this
      *         time slot.
      */
     default boolean fits( TimeSlot other ) {
-        return this.getStart().compareTo( other.getStart() ) <= 0
-                && this.getEnd().compareTo( other.getEnd() ) >= 0;
+        return this.start()
+                .compareTo( other.start() ) <= 0
+               && this.end()
+                        .compareTo( other.end() ) >= 0;
     }
 
     /**
@@ -94,8 +96,8 @@ public interface TimeSlot extends Comparable<TimeSlot> {
      * @param day for the time
      * @return end Time.
      */
-    default LocalTime getEndTime( LocalDay day ) {
-        return day.timeOfInstant( getEnd() );
+    default LocalTime endTime(LocalDay day) {
+        return day.timeOfInstant( end() );
     }
 
     /**
@@ -104,8 +106,8 @@ public interface TimeSlot extends Comparable<TimeSlot> {
      * @param day for the time
      * @return start Time
      */
-    default LocalTime getStartTime( LocalDay day ) {
-        return day.timeOfInstant( getStart() );
+    default LocalTime startTime(LocalDay day) {
+        return day.timeOfInstant( start() );
     }
 
     /**
@@ -114,8 +116,8 @@ public interface TimeSlot extends Comparable<TimeSlot> {
      * @param day provides time zone
      * @return the date on which the TimeSlot starts.
      */
-    default LocalDate getStartDate( LocalDay day ) {
-        return day.dateOfInstant( getStart() );
+    default LocalDate startDate( LocalDay day ) {
+        return day.dateOfInstant( start() );
     }
 
     /**
@@ -124,7 +126,7 @@ public interface TimeSlot extends Comparable<TimeSlot> {
      * @param day provides time zone
      * @return the date on which the TimeSlot ends.
      */
-    default LocalDate getEndDate( LocalDay day ) {
-        return day.dateOfInstant( getEnd() );
+    default LocalDate endDate( LocalDay day ) {
+        return day.dateOfInstant( end() );
     }
 }

--- a/src/main/java/appointmentplanner/api/Timeline.java
+++ b/src/main/java/appointmentplanner/api/Timeline.java
@@ -110,8 +110,8 @@ public interface Timeline {
      */
     default Optional<Appointment> addAppointment( LocalDay forDay,
             AppointmentRequest appointmentRequest ) {
-        return addAppointment( forDay, appointmentRequest.getAppointmentData(),
-                appointmentRequest.getStartTime() );
+        return addAppointment( forDay, appointmentRequest.appointmentData(),
+                appointmentRequest.startTime() );
     }
 
     /**

--- a/src/main/java/appointmentplanner/api/Timeline.java
+++ b/src/main/java/appointmentplanner/api/Timeline.java
@@ -34,7 +34,7 @@ public interface Timeline {
      *
      * @return Number of appointments on this timeline.
      */
-    int getNrOfAppointments();
+    int nrOfAppointments();
 
     /**
      * Get the number of gaps between start and en of day and between the
@@ -161,7 +161,7 @@ public interface Timeline {
      *
      * @return list of all appointments.
      */
-    default List<Appointment> getAppointments() {
+    default List<Appointment> appointments() {
         return appointmentStream().collect( Collectors.toList() );
     }
 
@@ -188,7 +188,7 @@ public interface Timeline {
      * @param duration the requested duration for an appointment
      * @return a list of gaps in which the appointment can be scheduled.
      */
-    List<TimeSlot> getGapsFitting( Duration duration );
+    List<TimeSlot> gapsFitting( Duration duration );
 
     /**
      * Check if an appointment of the given duration can be scheduled.
@@ -205,7 +205,7 @@ public interface Timeline {
      * @param duration the requested duration for an appointment
      * @return a list of start times on which an appointment can be scheduled
      */
-    List<TimeSlot> getGapsFittingReversed( Duration duration );
+    List<TimeSlot> gapsFittingReversed( Duration duration );
 
     /**
      * Get the gaps matching the given duration, smallest fitting first.
@@ -213,7 +213,7 @@ public interface Timeline {
      * @param duration required
      * @return list of all gaps fitting, ordered, smallest gap first.
      */
-    List<TimeSlot> getGapsFittingSmallestFirst( Duration duration );
+    List<TimeSlot> gapsFittingSmallestFirst( Duration duration );
 
     /**
      * Get the gaps matching the given duration, largest fitting first.
@@ -221,7 +221,7 @@ public interface Timeline {
      * @param duration required
      * @return list of all gaps fitting, ordered, largest gap first.
      */
-    List<TimeSlot> getGapsFittingLargestFirst( Duration duration );
+    List<TimeSlot> gapsFittingLargestFirst( Duration duration );
 
     /**
      * Find matching free time slots in this and other TimeLines. To facilitate
@@ -231,5 +231,5 @@ public interface Timeline {
      * @param other day plans
      * @return the list of free slots that all DayPlans share.
      */
-    List<TimeSlot> getMatchingFreeSlotsOfDuration( Duration minLength, List<Timeline> other );
+    List<TimeSlot> matchingFreeSlotsOfDuration( Duration minLength, List<Timeline> other );
 }


### PR DESCRIPTION
# Suggest records where possible

* All 'get' prefixes are dropped for better readability.
* Less code to write, easier to get good coverage.
* More profit :+1: 

cut-it-up implementation has been updated accordingly, and achieves 100% pit coverage.